### PR TITLE
Add CSS formatting capability to label method

### DIFF
--- a/jquery-turtle.js
+++ b/jquery-turtle.js
@@ -3239,15 +3239,42 @@ var turtlefn = {
   }),
   label: wraphelp(
   ["<u>label(text)</u> Labels the current position with HTML: " +
-      "<mark>label 'remember'</mark>"],
-  function label(html, fn) {
+      "<mark>label 'remember'</mark>",
+   "<u>label(text, styles)</u> Apply CSS styles to the label: " +
+      "<mark>label 'big', { fontSize: 100 }</mark>"],
+
+  function label(html, styles, fn) {
+    if (!fn && $.isFunction(styles)) {
+      fn = styles;
+      styles = null;
+    }
+    if ($.isNumeric(styles)) {
+      styles = { fontSize: styles };
+    }
     return this.plan(function() {
-      var out = output(html, 'label').css({
+      var applyStyles = {}, currentStyles = this.prop('style');
+      // For defaults, copy inline styles of the turtle itself except for
+      // properties in the following list (these are the properties used to
+      // make the turtle look like a turtle).
+      for (var j = 0; j < currentStyles.length; ++j) {
+        var styleProperty = currentStyles[j];
+        if (/^(?:width|height|opacity|background-image|background-size)$/.test(
+          styleProperty) || /transform/.test(styleProperty)) {
+          continue;
+        }
+        applyStyles[$.camelCase(styleProperty)] = currentStyles[styleProperty];
+      }
+      // And then override turtle styles with absolute positioning; and
+      // finally override all styles with any explicity provided styles.
+      $.extend(applyStyles, {
         position: 'absolute',
         display: 'table',
         top: 0,
         left: 0
-      }).addClass('turtle').appendTo(getTurtleField());
+      }, styles);
+      // Place the label on the screen using the figured styles.
+      var out = output(html, 'label').css(applyStyles)
+          .addClass('turtle').appendTo(getTurtleField());
       // Mimic the current position and rotation and scale of the turtle.
       out.css({
         turtlePosition: computeTargetAsTurtlePosition(

--- a/test/label.html
+++ b/test/label.html
@@ -1,0 +1,56 @@
+<script src="lib/qunit.js"></script>
+<link href="lib/qunit.css" rel="stylesheet">
+<script src="lib/jquery.js"></script>
+<script src="../jquery-turtle.js"></script>
+<body>
+<div id="qunit"></div>
+<script>
+eval($.turtle());
+module("Label test.");
+function rounded(obj) {
+  var result;
+  if ($.isNumeric(obj)) {
+    return Math.round(obj);
+  }
+  if ($.isArray(obj)) {
+    result = [];
+    for (var j = 0; j < obj.length; ++j) {
+      result.push(rounded(obj[j]));
+    }
+    return result;
+  }
+  if ($.isObject(obj)) {
+    result = {};
+    for (var k in obj) {
+      result[k] = rounded(obj[k]);
+      return result;
+    }
+  }
+}
+asyncTest("Outputs some labels.", function() {
+  speed(10);
+  label('small');
+  fd(50)
+  css('fontSize', 100);
+  label('big');
+  bk(100)
+  rt(90);
+  label('mid', { fontSize: 50 });
+  fd(150)
+  label('giant', 150);
+  done(function() {
+    ok($('label:contains(small)').width() < $('label:contains(mid)').width());
+    ok($('label:contains(mid)').width() < $('label:contains(big)').width());
+    ok($('label:contains(big)').width() < $('label:contains(giant)').width());
+    deepEqual(rounded($('label:contains(small)').getxy()), [0, 0]);
+    deepEqual(rounded($('label:contains(big)').getxy()), [0, 50]);
+    deepEqual(rounded($('label:contains(mid)').getxy()), [0, -50]);
+    deepEqual(rounded($('label:contains(giant)').getxy()), [150, -50]);
+    equal(rounded($('label:contains(small)').direction()), 0);
+    equal(rounded($('label:contains(big)').direction()), 0);
+    equal(rounded($('label:contains(mid)').direction()), 90);
+    equal(rounded($('label:contains(giant)').direction()), 90);
+    start();
+  });
+});
+</script>


### PR DESCRIPTION
Feedback from the hackathon: the label method should take an optional argument that allows the text style to be controlled.  So two things here: css attributes from the turtle itself are applied (so that you can set a default fontSize etc); and if css attributes are passed as a second argument to the label method, they are applied.
