### PR TITLE
Fix crash when computing convex hull of a rectangular element.

### DIFF
--- a/jquery-turtle.js
+++ b/jquery-turtle.js
@@ -1025,7 +1025,7 @@ function getCornersInPageCoordinates(elem, untransformed) {
       totalTransform = matrixProduct(totalParentTransform, currentTransform),
       inverseParent = inverse2x2(totalParentTransform),
       out = {},
-      origin = getTurtleOrigin(elem, inverseParent),
+      origin = getTurtleOrigin(elem, inverseParent, out),
       gbcr = out.gbcr,
       hull = polyToVectorsOffset(getTurtleData(elem).hull, origin) || [
         [gbcr.left, gbcr.top],

--- a/test/inside.html
+++ b/test/inside.html
@@ -1,0 +1,21 @@
+<script src="lib/qunit.js"></script>
+<link href="lib/qunit.css" rel="stylesheet">
+<script src="lib/jquery.js"></script>
+<script src="../jquery-turtle.js"></script>
+<body>
+<div id="qunit"></div>
+<script>
+eval($.turtle());
+module("Inside test.");
+asyncTest("Verifies that 'inside' works.", function() {
+  speed(Infinity);
+  ok(inside(window));
+  p = write('hello');
+  ok(p.inside(window));
+  p.slide(-25, 0);
+  ok(!p.inside(window));
+  fd(2000);
+  ok(!inside(window));
+  start();
+});
+</script>


### PR DESCRIPTION
A missing "out" parameter caused getCornersInPageCoordinates to crash whenever computing the corners of a regular rectangular element without a turtleHull.
