### PR TITLE
Allow detailed pen styles to be set by structure.

### DIFF
--- a/jquery-turtle.js
+++ b/jquery-turtle.js
@@ -3378,6 +3378,8 @@ var turtlefn = {
       penstyle = 'black';
     } else if (penstyle === null) {
       penstyle = 'none';
+    } else if ($.isPlainObject(penstyle)) {
+      penstyle = writePenStyle(penstyle);
     }
     this.plan(function(j, elem) {
       cc.appear(j);
@@ -3450,6 +3452,9 @@ var turtlefn = {
       "<mark>pen path; rt 100, 90; fill blue</mark>"],
   function fill(cc, style) {
     if (!style) { style = 'black'; }
+    else if ($.isPlainObject(style)) {
+      style = writePenStyle(style);
+    }
     var ps = parsePenStyle(style, 'fillStyle');
     this.plan(function(j, elem) {
       cc.appear(j);

--- a/test/pen.html
+++ b/test/pen.html
@@ -1,0 +1,63 @@
+<script src="lib/qunit.js"></script>
+<link href="lib/qunit.css" rel="stylesheet">
+<script src="lib/jquery.js"></script>
+<script src="../jquery-turtle.js"></script>
+<body>
+<div id="qunit"></div>
+<script>
+eval($.turtle());
+module("Pen styles test.");
+asyncTest("Draws a series of lines with different style pens.", function() {
+  speed(Infinity);
+  pen({strokeStyle: red, lineWidth:100, lineCap: 'butt'});
+  fd(10);
+  ok(touches(red));
+  ok(touches(transparent));
+  pen(null)
+  fd(20);
+  ok(!touches(red));
+  bk(20);
+  slide(50)
+  ok(touches(red));
+  slide(20)
+  ok(!touches(red));
+  slide(-120)
+  ok(touches(red));
+  slide(-20)
+  ok(!touches(red));
+  rt(45);
+  pen({strokeStyle: blue, lineWidth:100, lineCap: 'square'});
+  fd(10);
+  ok(touches(blue));
+  ok(!touches(transparent));
+  pen(null);
+  slide(50, 50);
+  ok(touches(blue));
+  ok(touches(transparent));
+  ok(touches(red));
+  pen({strokeStyle: green}, 100);
+  bk(10)
+  ok(touches(green));
+  ok(!touches(transparent));
+  pen(null);
+  slide(50, 50);
+  ok(touches(transparent));
+  ok(!touches(green));
+  slide(-10, -10);
+  ok(touches(transparent));
+  ok(touches(green));
+  pen('path');
+  bk(60); rt(120);
+  bk(60); rt(120);
+  bk(60); rt(120);
+  fill({strokeStyle: pink, lineWidth: 3, fillStyle: brown});
+  ok(touches(pink));
+  ok(touches(brown));
+  ok(touches(green));
+  lt(150);fd(33);
+  ok(touches(brown));
+  ok(!touches(green));
+  ok(!touches(pink));
+  start();
+});
+</script>


### PR DESCRIPTION
I notice a lot of high school students drawing bar graphs.  This commit adds the ability to set more detailed pen styles by passing an object to the "pen" function.  So, for example, you can say:

<pre>
pen
  strokeStyle: red
  lineCap: 'butt'
  lineWidth: 100

fd 30
</pre>


And the result will be a bar 100 pixels wide and 30 pixels tall, instead of a big oval shape (the default lineCap for turtle drawings is 'round', which is nice for geometric shapes but not so good for bar graphs).
