### PR TITLE
Improve cached page-position heuristic.

### DIFF
--- a/jquery-turtle.js
+++ b/jquery-turtle.js
@@ -822,7 +822,7 @@ function cleanedStyle(trans) {
 // center of rotation when no transforms are applied) in page coordinates.
 function getTurtleOrigin(elem, inverseParent, extra) {
   var state = $.data(elem, 'turtleData');
-  if (state && state.quickhomeorigin && state.down && !extra) {
+  if (state && state.quickhomeorigin && state.down && state.style && !extra) {
     return state.quickhomeorigin;
   }
   var hidden = ($.css(elem, 'display') === 'none'),
@@ -845,7 +845,7 @@ function getTurtleOrigin(elem, inverseParent, extra) {
     extra.localorigin = transformOrigin;
   }
   var result = addVector([gbcr.left, gbcr.top], transformOrigin);
-  if (state && state.down) {
+  if (state && state.down && state.style) {
     state.quickhomeorigin = result;
   }
   return result;
@@ -1039,7 +1039,7 @@ function getCenterInPageCoordinates(elem) {
     return getRoundedCenterLTWH(0, 0, dw(), dh());
   }
   var state = getTurtleData(elem);
-  if (state && state.quickpagexy && state.down) {
+  if (state && state.quickpagexy && state.down && state.style) {
     return state.quickpagexy;
   }
   var tr = getElementTranslation(elem),
@@ -1049,7 +1049,7 @@ function getCenterInPageCoordinates(elem) {
       origin = getTurtleOrigin(elem, inverseParent),
       pos = addVector(matrixVectorProduct(totalParentTransform, tr), origin),
       result = { pageX: pos[0], pageY: pos[1] };
-  if (state && simple && state.down) {
+  if (state && simple && state.down && state.style) {
     state.quickpagexy = result;
   }
   return result;

--- a/test/field.html
+++ b/test/field.html
@@ -1,0 +1,43 @@
+<script src="lib/qunit.js"></script>
+<link href="lib/qunit.css" rel="stylesheet">
+<script src="lib/jquery.js"></script>
+<script src="../jquery-turtle.js"></script>
+<body>
+<div id="qunit"></div>
+<script>
+eval($.turtle());
+module("Field test.");
+asyncTest("Moves the field to translate the turtle.", function() {
+  speed(Infinity);
+  var homepos = pagexy();
+  pen(red);
+  fd(100);
+  rt(90);
+  fd(100);
+  rt(90);
+  fd(100);
+  rt(90);
+  fd(100);
+  rt(90);
+  pen(null);
+  $('#field').bk(100);
+  ok(!touches(red));
+  fd(100);
+  ok(touches(red));
+  fd(100);
+  ok(touches(red));
+  home();
+  ok(!touches(red));
+  moveto(homepos);
+  ok(touches(red));
+  $('#field').fd(100);
+  ok(touches(red));
+  bk(100);
+  ok(touches(red));
+  bk(100);
+  ok(!touches(red));
+  done(function() {
+    start();
+  });
+});
+</script>

--- a/test/square.html
+++ b/test/square.html
@@ -26,23 +26,25 @@ asyncTest("Draws a square changing speed along the way.", function() {
   done(function() {
     speed(Infinity);
     wear('turtle');
-    var j;
-    for (j = 0; j < 4; ++j) {
-      ok(touches(red));
-      fd(50);
-      ok(touches(red));
-      fd(50);
-      rt(90);
-    }
-    jump(-25,-25);
-    for (j = 0; j < 4; ++j) {
-      ok(!touches(red));
-      fd(75);
-      ok(!touches(red));
-      fd(75);
-      rt(90);
-    }
-    start();
+    plan(function() {
+      var j;
+      for (j = 0; j < 4; ++j) {
+        ok(touches(red));
+        fd(50);
+        ok(touches(red));
+        fd(50);
+        rt(90);
+      }
+      jump(-25,-25);
+      for (j = 0; j < 4; ++j) {
+        ok(!touches(red));
+        fd(75);
+        ok(!touches(red));
+        fd(75);
+        rt(90);
+      }
+      start();
+    });
   });
 });
 </script>


### PR DESCRIPTION
Instead of caching the page position when the pen is simply down,
now it requires the pen both to be down and have a non-null style.
This allows absolute positions to be recomputed correctly after
a parent element is transformed when the turtle isn't drawing
(either because the pen is up or because the pen is null).

This commit also adds a test and fixes a test to be less flaky.
