### PR TITLE
Make readstr show a bigger input box.

### DIFF
--- a/jquery-turtle.js
+++ b/jquery-turtle.js
@@ -5913,9 +5913,10 @@ function input(name, callback, numeric) {
     name = null;
   }
   name = $.isNumeric(name) || name ? name : '&rArr;';
-  var textbox = $('<input>').css({margin:0, padding:0}),
+  var textbox = $('<input>').css({margin:0, padding:0, flex:1}),
       label = $(
-      '<label style="display:block">' +
+      (numeric >= 0 ? '<label style="display:table">'
+                    : '<label style="display:flex">') +
       name + '&nbsp;' +
       '</label>').append(textbox),
       thisval = $([textbox[0], label[0]]),
@@ -5933,7 +5934,7 @@ function input(name, callback, numeric) {
     dodebounce();
     lastseen = val;
     textbox.remove();
-    label.append(val);
+    label.append(val).css({display: 'table'});
     if (numeric > 0 || (
       numeric >= 0 && $.isNumeric(val) && ('' + parseFloat(val) == val))) {
       val = parseFloat(val);


### PR DESCRIPTION
This changes the default formatting for the input box in readstr to fill the width of the window.

This fits common uses of readstr, for example:
- In an encryption program, you'd typically want to use readstr to enter a whole sentence to encrypt.
- In an eliza program, you'd want to enter a whole sentence also.

read and readnum still use a (small) default input size.
