### PR TITLE
Fix a bug in the interaction of jump and fill.

### DIFF
--- a/jquery-turtle.js
+++ b/jquery-turtle.js
@@ -1912,7 +1912,7 @@ function flushPenState(elem) {
   if (!state.down) {
     // Penup when saving path will start a new segment if one isn't started.
     if (state.path.length && state.path[0].length) {
-      state.path.shift([]);
+      state.path.unshift([]);
     }
     return;
   }

--- a/test/dotfill.html
+++ b/test/dotfill.html
@@ -6,7 +6,7 @@
 <div id="qunit"></div>
 <script>
 eval($.turtle());
-module("Speed Infinity test.");
+module("Dot and fill test.");
 asyncTest("Test of dots and fills.", function() {
   speed(Infinity);
   pen(fill);

--- a/test/jump.html
+++ b/test/jump.html
@@ -1,0 +1,23 @@
+<script src="lib/qunit.js"></script>
+<link href="lib/qunit.css" rel="stylesheet">
+<script src="lib/jquery.js"></script>
+<script src="../jquery-turtle.js"></script>
+<body>
+<div id="qunit"></div>
+<script>
+eval($.turtle());
+module("Jump and fill test.");
+asyncTest("Test that jumpto and fill work together.", function() {
+  speed(Infinity);
+  pen(path);
+  jumpto(-50, -50);
+  rt(100, 100);
+  jumpto(-50, 50);
+  rt(100, 100);
+  fill(red);
+  ok(touches(red));
+  jumpto(0, 50);
+  ok(!touches(red));
+  start();
+});
+</script>


### PR DESCRIPTION
When using a pen fill and lifting the pen, it should allow you to
start a second (disconnected) path.  A typo in the code caused this
to be broken.  Added a unit test that exercises this functionality.
