### PR TITLE
Possible audio fix for older browsers.

### DIFF
--- a/jquery-turtle.js
+++ b/jquery-turtle.js
@@ -6253,8 +6253,8 @@ function playABC(done, args) {
             o.stop(rtime);
           } else {
             // Early draft web audio spec.
-            o.start(time);
-            o.stop(rtime);
+            o.noteOn(time);
+            o.noteOff(rtime);
           }
         }
       }


### PR DESCRIPTION
We had a report that audio was broken on older macs.

This is one possible fix.  Anthony, can you find a way to test this?
