### PR TITLE
Fix handling of px units in CSS hook setters.

### DIFF
--- a/jquery-turtle.js
+++ b/jquery-turtle.js
@@ -2508,8 +2508,8 @@ function makeTurtleXYHook(publicname, propx, propy, displace) {
           state = $.data(elem, 'turtleData'),
           otx = ts.tx, oty = ts.ty, qpxy;
       if (parts.length < 1 || parts.length > 2) { return; }
-      if (parts.length >= 1) { ts[propx] = parts[0]; }
-      if (parts.length >= 2) { ts[propy] = parts[1]; }
+      if (parts.length >= 1) { ts[propx] = parseFloat(parts[0]); }
+      if (parts.length >= 2) { ts[propy] = parseFloat(parts[1]); }
       else if (!displace) { ts[propy] = ts[propx]; }
       else { ts[propy] = 0; }
       elem.style[transform] = writeTurtleTransform(ts);
@@ -4899,8 +4899,8 @@ $.extend(true, $, {
     turtleForward: makeTurtleForwardHook(),
     turtleTurningRadius: makeTurningRadiusHook(),
     turtlePosition: makeTurtleXYHook('turtlePosition', 'tx', 'ty', true),
-    turtlePositionX: makeTurtleHook('tx', identity, 'px', true),
-    turtlePositionY: makeTurtleHook('ty', identity, 'px', true),
+    turtlePositionX: makeTurtleHook('tx', parseFloat, 'px', true),
+    turtlePositionY: makeTurtleHook('ty', parseFloat, 'px', true),
     turtleRotation: makeTurtleHook('rot', maybeArcRotation, 'deg', true),
     turtleScale: makeTurtleXYHook('turtleScale', 'sx', 'sy', false),
     turtleScaleX: makeTurtleHook('sx', identity, '', false),

--- a/test/animate.html
+++ b/test/animate.html
@@ -1,0 +1,39 @@
+<script src="lib/qunit.js"></script>
+<link href="lib/qunit.css" rel="stylesheet">
+<script src="lib/jquery.js"></script>
+<script src="../jquery-turtle.js"></script>
+<body>
+<div id="qunit"></div>
+<script>
+eval($.turtle());
+module("Low level animation test.");
+asyncTest("Draws a square using low-level animation.", function() {
+  speed(10);
+  pen(red);
+  turtle.animate({turtleForward: '+=100'}, 0.1);
+  turtle.animate({turtlePositionX: '+=100'}, 0.1);
+  turtle.animate({turtlePositionY: '0'}, 0.1);
+  turtle.animate({turtleRotation: '-=90'}, 0.1);
+  turtle.animate({turtleForward: '+=100'}, 0.1);
+  turtle.animate({turtleRotation: '0'}, 0.1);
+  pen(null);
+  done(function() {
+    turtle.speed(Infinity);
+    plan(function() {
+      var j;
+      for (j = 0; j < 4; ++j) {
+        ok(touches(red));
+        fd(50);
+        ok(touches(red));
+        fd(50);
+        rt(90);
+      }
+      turtle.css({turtlePosition: '200px -100px'});
+      ok(!touches(red));
+      turtle.css({turtlePosition: '100px -100px'});
+      ok(touches(red));
+      start();
+    });
+  });
+});
+</script>


### PR DESCRIPTION
turtle.animate { turtlePositionX: '+=100' } had been broken becuase
the CSS hooks for turtlePosition\* were not handling things when
the units "px" were included in the set value.  This is now fixed,
and animate works again.  A test is added for this case.
