### PR TITLE
Added a reportEvent to seeeval

### DIFF
--- a/jquery-turtle.js
+++ b/jquery-turtle.js
@@ -9920,6 +9920,7 @@ function seeeval(scope, code) {
     if (scopes[scope].e) { ef = scopes[scope].e; }
     if (scopes[scope].t) { et = scopes[scope].t; }
   }
+  debug.reportEvent("seeeval", [scope, code]);
   return ef.call(et, code);
 }
 


### PR DESCRIPTION
Just updated seeeval to support debugging by allowing us to identify events that do not need to be traced. 