### PR TITLE
"grow" works the way "scale" should have worked.

### DIFF
--- a/test/globals.html
+++ b/test/globals.html
@@ -288,6 +288,7 @@ asyncTest("Verify no unexpected globals are introduced.", function() {
     "mirror",
     "twist",
     "scale",
+    "grow",
     "pause",
     "st",
     "ht",


### PR DESCRIPTION
Many people are using "scale" to change the size of a turtle where they don't want to change the size of a turtle step.  But currently when you "scale" a turtle, not only does it look bigger, it also draws everything bigger.

Some people want to draw things bigger, but when they do, they want to affect all turtles at once, not just one turtle individually.

It turns out that the semantics people want is much easier to implement than the semantics that currently exists.  So in this pull request, "grow" works the way that they want "scale" to work.

`turtle.grow(2)` will now just make that one turtle look twice as big without making it draw differently.
`origin.grow(2)` will grow all the turtles and change the whole coordinate system to make everything twice as far apart, thus affecting all future drawing.

Because so many programs use `turtle.scale(n)` today, this change preserves the current behavior for that old function name for now.

Also... the benefit of calling it `grow` instead of `scale` is that the word "scale" is a natural and common variable name that students want to use, so it's confusing.  It's a noun, not just a verb.  `grow` does not have this problem.