### PR TITLE
Rename log to debug.

### DIFF
--- a/jquery-turtle.js
+++ b/jquery-turtle.js
@@ -8405,7 +8405,7 @@ $.turtle = function turtle(id, options) {
       global.onerror = see;
     }
     // Set up an alias.
-    global.log = see;
+    global.debug = see;
   }
   // Copy $.turtle.* functions into global namespace.
   if (!('functions' in options) || options.functions) {
@@ -10699,6 +10699,11 @@ function initconsolelog() {
       var _log = global.console._log = global.console.log;
       global.console.log = function log() {
         _log.apply(this, arguments);
+        see.apply(this, arguments);
+      }
+      var _debug = global.console._debug = global.console.debug;
+      global.console.debug = function debug() {
+        _debug.apply(this, arguments);
         see.apply(this, arguments);
       }
     }

--- a/jquery-turtle.js
+++ b/jquery-turtle.js
@@ -8406,6 +8406,8 @@ $.turtle = function turtle(id, options) {
     }
     // Set up an alias.
     global.debug = see;
+    // 'debug' should be used now instead of log
+    deprecate(global, 'log', 'debug');
   }
   // Copy $.turtle.* functions into global namespace.
   if (!('functions' in options) || options.functions) {

--- a/test/globals.html
+++ b/test/globals.html
@@ -32,6 +32,7 @@ asyncTest("Verify no unexpected globals are introduced.", function() {
     "lastmousemove",
     "see",
     "debug",
+    "log",
     "printpage",
     "interrupt",
     "cs",

--- a/test/globals.html
+++ b/test/globals.html
@@ -31,7 +31,7 @@ asyncTest("Verify no unexpected globals are introduced.", function() {
     "lastmousedown",
     "lastmousemove",
     "see",
-    "log",
+    "debug",
     "printpage",
     "interrupt",
     "cs",


### PR DESCRIPTION
To make space for using `log` for math.