### PR TITLE
Replaced the readvoice command with the listen command.

### DIFF
--- a/jquery-turtle.js
+++ b/jquery-turtle.js
@@ -8046,9 +8046,9 @@ var dollar_turtle_methods = {
       "converts input to a number: " +
       "<mark>readstr 'Enter code', (v) -> write v.length + ' long'</mark>"],
   doOutput, function readstr(a, b) { return prepareInput(a, b, 'text'); }),
-  readvoice: wrapglobalcommand('readvoice',
-  ["<u>readvoice(html, fn)</u> Reads voice input, if the browser supports it:" +
-      "<mark>readvoice 'Say something', (v) -> write v</mark>"],
+  listen: wrapglobalcommand('listen',
+  ["<u>listen(html, fn)</u> Reads voice input, if the browser supports it:" +
+      "<mark>listen 'Say something', (v) -> write v</mark>"],
   doOutput, function readstr(a, b) { return prepareInput(a, b, 'voice'); }),
   menu: wrapglobalcommand('menu',
   ["<u>menu(map)</u> shows a menu of choices and calls a function " +

--- a/test/globals.html
+++ b/test/globals.html
@@ -60,7 +60,7 @@ asyncTest("Verify no unexpected globals are introduced.", function() {
     "typeline",
     "read",
     "readnum",
-    "readvoice",
+    "listen",
     "readstr",
     "menu",
     "random",


### PR DESCRIPTION
@davidbau I found the name of the 'readvoice' command to be unintuitive, so I changed it to 'listen' to keep it consistent with the 'say', 'read', and 'write' commands. What do you think?